### PR TITLE
make dynogen executable locally

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "pretest": "yarn lint",
     "test": "jest",
     "prebuild": "rm -rf ./dist",
-    "build": "tsc --declaration --outDir ./dist --declarationDir ./dist -p tsconfig.json"
+    "build": "tsc --declaration --outDir ./dist --declarationDir ./dist -p tsconfig.json && chmod +x ./dist/index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import yargs = require('yargs');
 import { DEFAULT_DYNOGEN_CONFIG_PATH } from './constants';
 


### PR DESCRIPTION
Lerna is having trouble changing the permission of the symlinked bin file to be executable. This change adds a shebang and chmods when a new build has been output

Signed-off-by: Charles Kenney <charlesc.kenney@gmail.com>